### PR TITLE
Change src attribute of images by external commands

### DIFF
--- a/sources/cysboard.h
+++ b/sources/cysboard.h
@@ -243,7 +243,11 @@ void CysBoard::update() {
 
     // execute commands and output result on each update
     for(auto& node: m_execNodes) {
-        stringToDomText(CallProgram::execute(DOM_TEXT_TO_CSTR(node.get_attribute("cmd"))), node);
+        if(node.get_element_type() == "img") {
+            stringToDomAttr(CallProgram::execute(DOM_TEXT_TO_CSTR(node.get_attribute("cmd"))), node, "src");
+        } else {
+            stringToDomText(CallProgram::execute(DOM_TEXT_TO_CSTR(node.get_attribute("cmd"))), node);
+        }
     }
 
     usleep(m_updateInterval * 1000000);

--- a/sources/util.h
+++ b/sources/util.h
@@ -117,6 +117,19 @@ static inline void stringToDomText(const std::string& source, sciter::dom::eleme
 
 
 /**
+ * @brief Converts a std::string to be set as an attribute on a DOM element
+ * @param source The value of the parameter
+ * @param destination The DOM element
+ * @param attr The attribute name to set
+ */
+static inline void stringToDomAttr(const std::string& source, sciter::dom::element& destination, const std::string& attr) {
+    if(destination.is_valid()) {
+        destination.set_attribute(attr.c_str(), (const WCHAR*) aux::utf2w(source));
+    }
+}
+
+
+/**
  * @brief find all the elements in the DOM with the selector
  * @param root The root DOM element
  * @param selector CSS selector for the nodes


### PR DESCRIPTION
This can be useful, in my opinion, to implement a weather section or current song with album picture.

I have an example of that. With this, an image can be shown whose direction obtained from the execution of bash script (in my case) or any other executable. It's syntax is the same as executing a command and put the output into the DOM element text, but this one puts the result into the `src` attribute:
```html
<img class="album-pic" id="exec_13" cmd="/home/melchor9000/.config/cysboard/dbus.sh 4">
```

![captura de pantalla de 2017-05-01 18-04-33](https://cloud.githubusercontent.com/assets/1056963/25584994/b8e532f2-2e98-11e7-84ea-95e760a1acb4.png)
